### PR TITLE
Feature/pass session attributes

### DIFF
--- a/lambda/es-proxy-layer/lib/llm.js
+++ b/lambda/es-proxy-layer/lib/llm.js
@@ -192,12 +192,14 @@ async function get_qa_sagemaker(req, promptTemplateStr, context) {
 }
 
 // Invoke LLM via custom Lambda abstraction
-async function invoke_lambda(prompt, model_params, settings) {
+async function invoke_lambda(prompt, model_params, settings, sessionId, sessionAttributes) {
     const lambda = new Lambda(customSdkConfig('C006', { region }));
     const body = JSON.stringify({
         prompt,
         parameters: model_params,
         settings,
+        sessionId,
+        sessionAttributes,
     });
 
     qnabot.log(`Invoking Lambda: ${process.env.LLM_LAMBDA_ARN}`);
@@ -231,7 +233,11 @@ async function generate_query_lambda(req, promptTemplateStr) {
     const settings = req._settings;
     const [, , , prompt] = await make_qenerate_query_prompt(req, promptTemplateStr);
     qnabot.log(`Prompt: \nGENERATE QUERY PROMPT==>\n${prompt}\n<==PROMPT`);
-    return invoke_lambda(prompt, model_params, settings);
+
+    // Extract sessionId and sessionAttributes from the request
+    const sessionId = req._event.sessionId;
+    const sessionAttributes = req._event.sessionState.sessionAttributes;
+    return invoke_lambda(prompt, model_params, settings, sessionId, sessionAttributes);
 }
 async function get_qa_lambda(req, promptTemplateStr, context) {
     const model_params = JSON.parse(req._settings.LLM_QA_MODEL_PARAMS || default_params_stg);
@@ -241,6 +247,10 @@ async function get_qa_lambda(req, promptTemplateStr, context) {
     const query = get_query(req);
     const [, , , prompt] = await make_qa_prompt(req, promptTemplateStr, context, input, query);
     qnabot.log(`QUESTION ANSWERING PROMPT: \nPROMPT==>\n${prompt}\n<==PROMPT`);
+
+    // Extract sessionId and sessionAttributes from the request
+    const sessionId = req._event.sessionId;
+    const sessionAttributes = req._event.sessionState.sessionAttributes;
     return invoke_lambda(prompt, model_params, settings);
 }
 

--- a/lambda/es-proxy-layer/lib/llm.js
+++ b/lambda/es-proxy-layer/lib/llm.js
@@ -251,7 +251,7 @@ async function get_qa_lambda(req, promptTemplateStr, context) {
     // Extract sessionId and sessionAttributes from the request
     const sessionId = req._event.sessionId;
     const sessionAttributes = req._event.sessionState.sessionAttributes;
-    return invoke_lambda(prompt, model_params, settings);
+    return invoke_lambda(prompt, model_params, settings, sessionId, sessionAttributes);
 }
 
 function clean_standalone_query(query) {

--- a/lambda/es-proxy-layer/lib/llm.js
+++ b/lambda/es-proxy-layer/lib/llm.js
@@ -192,14 +192,14 @@ async function get_qa_sagemaker(req, promptTemplateStr, context) {
 }
 
 // Invoke LLM via custom Lambda abstraction
-async function invoke_lambda(prompt, model_params, settings, sessionId, sessionAttributes) {
+async function invoke_lambda(prompt, model_params, settings, sessionId, sessionState) {
     const lambda = new Lambda(customSdkConfig('C006', { region }));
     const body = JSON.stringify({
         prompt,
         parameters: model_params,
         settings,
         sessionId,
-        sessionAttributes,
+        sessionState,
     });
 
     qnabot.log(`Invoking Lambda: ${process.env.LLM_LAMBDA_ARN}`);
@@ -234,10 +234,10 @@ async function generate_query_lambda(req, promptTemplateStr) {
     const [, , , prompt] = await make_qenerate_query_prompt(req, promptTemplateStr);
     qnabot.log(`Prompt: \nGENERATE QUERY PROMPT==>\n${prompt}\n<==PROMPT`);
 
-    // Extract sessionId and sessionAttributes from the request
+    // Extract sessionId and sessionState from the request
     const sessionId = req._event.sessionId;
-    const sessionAttributes = req._event.sessionState.sessionAttributes;
-    return invoke_lambda(prompt, model_params, settings, sessionId, sessionAttributes);
+    const sessionState = req._event.sessionState;
+    return invoke_lambda(prompt, model_params, settings, sessionId, sessionState);
 }
 async function get_qa_lambda(req, promptTemplateStr, context) {
     const model_params = JSON.parse(req._settings.LLM_QA_MODEL_PARAMS || default_params_stg);
@@ -248,10 +248,10 @@ async function get_qa_lambda(req, promptTemplateStr, context) {
     const [, , , prompt] = await make_qa_prompt(req, promptTemplateStr, context, input, query);
     qnabot.log(`QUESTION ANSWERING PROMPT: \nPROMPT==>\n${prompt}\n<==PROMPT`);
 
-    // Extract sessionId and sessionAttributes from the request
+    // Extract sessionId and sessionState from the request
     const sessionId = req._event.sessionId;
-    const sessionAttributes = req._event.sessionState.sessionAttributes;
-    return invoke_lambda(prompt, model_params, settings, sessionId, sessionAttributes);
+    const sessionState = req._event.sessionState;
+    return invoke_lambda(prompt, model_params, settings, sessionId, sessionState);
 }
 
 function clean_standalone_query(query) {


### PR DESCRIPTION
This PR aims to enhance the functionality of our Lambda invocation process by including session details (`sessionId` and `sessionAttributes`) in the invocation payload. These changes allow downstream Lambda functions to access session-specific information.

- Added `sessionId` and `sessionAttributes` as parameters to the `invoke_lambda` function.
- Modified the payload in `invoke_lambda` to include `sessionId` and `sessionAttributes`.
- Adjusted `generate_query_lambda` to extract and pass `sessionId` and `sessionAttributes` from the request to `invoke_lambda`.

